### PR TITLE
Fix applet icon not appearing in COSMIC Settings panel

### DIFF
--- a/res/net.tropicbliss.CosmicExtAppletCaffeine.desktop
+++ b/res/net.tropicbliss.CosmicExtAppletCaffeine.desktop
@@ -9,7 +9,7 @@ Terminal=false
 Categories=Cosmic;Iced;
 Keywords=Cosmic;Iced;
 # Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-Icon=net.tropicbliss.CosmicExtAppletCaffeine-symbolic
+Icon=net.tropicbliss.CosmicExtAppletCaffeine-full
 StartupNotify=true
 NoDisplay=true
 X-CosmicApplet=true


### PR DESCRIPTION
## Description

The Caffeine applet icon does not appear in the COSMIC Settings → Applets panel, even though it works correctly in the panel/dock.

## Root Cause

The  file references `net.tropicbliss.CosmicExtAppletCaffeine-symbolic` as the `Icon=`, but no file with that name exists in the repository. The available SVG icon files are:

- `net.tropicbliss.CosmicExtAppletCaffeine-full.svg`
- `net.tropicbliss.CosmicExtAppletCaffeine-empty.svg`

COSMIC Settings reads the `Icon=` key from the  file to display the applet icon. Since `-symbolic` doesn't exist, no icon shows up in settings.

The panel/dock works because `window.rs` uses `icon_button()` with the correct icon names (`-full`/`-empty`) directly.

## Fix

Changed `Icon=net.tropicbliss.CosmicExtAppletCaffeine-symbolic` to `Icon=net.tropicbliss.CosmicExtAppletCaffeine-full`.

## Comparison with working applet

| Applet | .desktop Icon= | SVG file exists? |
|---|---|---|
| System Stats | `io.github.rylan_x.cosmic-ext-applet-systemstats` | ✅ (`...systemstats.svg`) |
| Caffeine (before) | `net.tropicbliss.CosmicExtAppletCaffeine-symbolic` | ❌ (no `-symbolic.svg`) |
| Caffeine (after) | `net.tropicbliss.CosmicExtAppletCaffeine-full` | ✅ (`...-full.svg`) |

Closes #23