### PR TITLE
Fix applet crash when toggling caffeine from panel

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ i18n-embed = { version = "0.16.0", features = [
 ] }
 i18n-embed-fl = "0.10"
 rust-embed = "8.7.2"
-zbus = { version = "5.12.0", features = ["blocking-api"] }
+zbus = "5.12.0"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }
 tracing-log = "0.2.0"

--- a/src/caffeine.rs
+++ b/src/caffeine.rs
@@ -1,5 +1,4 @@
-use cosmic_time::once_cell::sync::Lazy;
-use zbus::{blocking::Connection, proxy, Result};
+use zbus::{Connection, proxy};
 
 #[proxy(
     interface = "org.freedesktop.ScreenSaver",
@@ -7,60 +6,46 @@ use zbus::{blocking::Connection, proxy, Result};
     default_path = "/ScreenSaver"
 )]
 trait ScreenSaver {
-    /// Inhibit the screensaver
-    fn inhibit(&self, application_name: &str, reason: &str) -> Result<u32>;
-
-    /// Uninhibit the screensaver using the cookie from a previous inhibit call
-    fn un_inhibit(&self, cookie: u32) -> Result<()>;
+    async fn inhibit(&self, application_name: &str, reason: &str) -> zbus::Result<u32>;
+    async fn un_inhibit(&self, cookie: u32) -> zbus::Result<()>;
 }
 
-fn get_proxy() -> Result<&'static ScreenSaverProxyBlocking<'static>> {
-    static PROXY: Lazy<Result<ScreenSaverProxyBlocking<'_>>> = Lazy::new(|| {
-        let conn = Connection::session()?;
-        Ok(ScreenSaverProxyBlocking::new(&conn)?)
-    });
-    let proxy = match PROXY.as_ref() {
-        Ok(proxy) => proxy,
-        Err(e) => return Err(e.clone()),
-    };
-    Ok(proxy)
+pub async fn inhibit() -> zbus::Result<u32> {
+    let connection = Connection::session().await?;
+    let proxy = ScreenSaverProxy::new(&connection).await?;
+    proxy
+        .inhibit(
+            env!("CARGO_PKG_NAME"),
+            concat!("Inhibited via ", env!("CARGO_PKG_NAME")),
+        )
+        .await
+}
+
+pub async fn uninhibit(cookie: u32) -> zbus::Result<()> {
+    let connection = Connection::session().await?;
+    let proxy = ScreenSaverProxy::new(&connection).await?;
+    proxy.un_inhibit(cookie).await
 }
 
 #[derive(Clone, Default)]
-/// Keep screen awake by inhibiting `org.freedesktop.ScreenSaver`
 pub struct Caffeine {
     cookie: Option<u32>,
 }
 
 impl Caffeine {
-    pub fn caffeinate(&mut self) -> Result<()> {
-        let proxy = get_proxy()?;
-        let cookie = proxy.inhibit(
-            env!("CARGO_PKG_NAME"),
-            concat!("Inhibited via ", env!("CARGO_PKG_NAME")),
-        )?;
-        self.cookie = Some(cookie);
-        Ok(())
-    }
-
-    pub fn decaffeinate(&mut self) -> Result<()> {
-        if let Some(cookie) = self.cookie {
-            let proxy = get_proxy()?;
-            proxy.un_inhibit(cookie)?;
-            self.cookie = None;
-        }
-        Ok(())
-    }
-
     pub fn is_caffeinated(&self) -> bool {
         self.cookie.is_some()
     }
 
-    pub fn cleanup(&self) -> Result<()> {
-        if let Some(cookie) = self.cookie {
-            let proxy = get_proxy()?;
-            proxy.un_inhibit(cookie)?;
-        }
-        Ok(())
+    pub fn set_cookie(&mut self, cookie: u32) {
+        self.cookie = Some(cookie);
+    }
+
+    pub fn clear_cookie(&mut self) {
+        self.cookie = None;
+    }
+
+    pub fn take_cookie(&mut self) -> Option<u32> {
+        self.cookie.take()
     }
 }

--- a/src/localize.rs
+++ b/src/localize.rs
@@ -12,9 +12,9 @@ struct Localizations;
 pub static LANGUAGE_LOADER: Lazy<FluentLanguageLoader> = Lazy::new(|| {
     let loader: FluentLanguageLoader = fluent_language_loader!();
 
-    loader
-        .load_fallback_language(&Localizations)
-        .expect("Error while loading fallback language");
+    if let Err(e) = loader.load_fallback_language(&Localizations) {
+        eprintln!("Error while loading fallback language: {e:?}");
+    }
 
     loader
 });

--- a/src/window.rs
+++ b/src/window.rs
@@ -90,8 +90,7 @@ impl cosmic::Application for Window {
     }
 
     fn init(core: cosmic::app::Core, _flags: ()) -> (Self, app::Task<Message>) {
-        let config: Config =
-            confy::load(ID, None).expect("config file should be in a valid format");
+        let config: Config = confy::load(ID, None).unwrap_or_default();
         let mut window = Window {
             core,
             persistent_state: config.clone(),
@@ -133,21 +132,22 @@ impl cosmic::Application for Window {
                 // Handle different mouse button clicks
                 match button {
                     mouse::Button::Right => {
-                        // Right-click opens the popup menu
                         return if let Some(p) = self.popup.take() {
                             destroy_popup(p)
-                        } else {
+                        } else if let Some(main_id) = self.core.main_window_id() {
                             let new_id = window::Id::unique();
                             self.popup.replace(new_id);
                             self.timeline = Timeline::new();
                             let popup_settings = self.core.applet.get_popup_settings(
-                                self.core.main_window_id().unwrap(),
+                                main_id,
                                 new_id,
                                 None,
                                 None,
                                 None,
                             );
                             get_popup(popup_settings)
+                        } else {
+                            Task::none()
                         };
                     }
                     mouse::Button::Left => {
@@ -209,7 +209,7 @@ impl cosmic::Application for Window {
                     if minutes_text.is_empty() {
                         return Task::none();
                     }
-                    let seconds = minutes_text.parse::<u64>().expect("valid u64 minutes text") * 60;
+                    let seconds = minutes_text.parse::<u64>().unwrap_or(0) * 60;
                     self.timer.start(Duration::from_secs(seconds));
                     self.secondary_window = None;
                     self.persistent_state.timer_state = Some(TimerDuration::CustomSeconds(seconds));
@@ -350,7 +350,9 @@ impl cosmic::Application for Window {
 
 impl Window {
     fn update_config(&self) {
-        confy::store(ID, None, &self.persistent_state).expect("cannot modify config");
+        if let Err(e) = confy::store(ID, None, &self.persistent_state) {
+            tracing::error!("Failed to save config: {e:?}");
+        }
     }
 
     fn set_stay_awake(&mut self, is_stay_awake: bool) {

--- a/src/window.rs
+++ b/src/window.rs
@@ -1,7 +1,7 @@
 use std::{sync::LazyLock, time::Duration};
 
 use cosmic::{
-    Element, Task, app,
+    app, Element, Task,
     applet::{menu_button, padded_control},
     cosmic_theme::Spacing,
     iced::{self, Alignment, Subscription, window, mouse},
@@ -15,6 +15,7 @@ use iced::{
 };
 use serde::{Deserialize, Serialize};
 
+use crate::caffeine;
 use crate::caffeine::Caffeine;
 use crate::fl;
 use crate::timer::Timer;
@@ -69,6 +70,8 @@ pub enum Message {
     CustomDurationStart,
     RememberStateToggle(chain::Toggler, bool),
     Settings,
+    DbusInhibitResult(std::result::Result<u32, zbus::Error>),
+    DbusUninhibitResult,
 }
 
 impl cosmic::Application for Window {
@@ -96,15 +99,20 @@ impl cosmic::Application for Window {
             persistent_state: config.clone(),
             ..Default::default()
         };
-        if config.remember_state {
+        let task = if config.remember_state {
             if let Some(timer_duration) = config.timer_state {
                 if let TimerDuration::CustomSeconds(secs) = timer_duration {
                     window.timer.start(Duration::from_secs(secs));
                 }
-                window.set_stay_awake(true);
+                Task::perform(caffeine::inhibit(), Message::DbusInhibitResult)
+                    .map(cosmic::Action::App)
+            } else {
+                Task::none()
             }
-        }
-        (window, Task::none())
+        } else {
+            Task::none()
+        };
+        (window, task)
     }
 
     fn on_close_requested(&self, id: window::Id) -> Option<Message> {
@@ -126,10 +134,9 @@ impl cosmic::Application for Window {
                     None
                 };
                 self.update_config();
-                self.set_stay_awake(is_stay_awake);
+                return self.toggle_caffeine(is_stay_awake);
             }
             Message::IconPressed(button) => {
-                // Handle different mouse button clicks
                 match button {
                     mouse::Button::Right => {
                         return if let Some(p) = self.popup.take() {
@@ -151,7 +158,6 @@ impl cosmic::Application for Window {
                         };
                     }
                     mouse::Button::Left => {
-                        // Left-click toggles caffeine state
                         let new_state = !self.caffeine.is_caffeinated();
                         self.persistent_state.timer_state = if new_state {
                             Some(TimerDuration::Infinite)
@@ -159,12 +165,22 @@ impl cosmic::Application for Window {
                             None
                         };
                         self.update_config();
-                        self.set_stay_awake(new_state);
+                        return self.toggle_caffeine(new_state);
                     }
-                    _ => {
-                        // Ignore other buttons
-                    }
+                    _ => {}
                 }
+            }
+            Message::DbusInhibitResult(Ok(cookie)) => {
+                self.caffeine.set_cookie(cookie);
+                let chain = chain::Toggler::on(STAY_AWAKE_CONTROLS.clone(), 1.);
+                self.timeline.set_chain(chain).start();
+            }
+            Message::DbusInhibitResult(Err(e)) => {
+                tracing::error!("Failed to inhibit screensaver: {e:?}");
+            }
+            Message::DbusUninhibitResult => {
+                let chain = chain::Toggler::off(STAY_AWAKE_CONTROLS.clone(), 1.);
+                self.timeline.set_chain(chain).start();
             }
             Message::Frame(now) => self.timeline.now(now),
             Message::Tick => {
@@ -173,7 +189,7 @@ impl cosmic::Application for Window {
                 if self.timer.timer_just_ended() {
                     self.persistent_state.timer_state = None;
                     self.update_config();
-                    self.set_stay_awake(false);
+                    return self.toggle_caffeine(false);
                 }
             }
             Message::SetTimer(minutes) => {
@@ -181,7 +197,7 @@ impl cosmic::Application for Window {
                 self.timer.start(Duration::from_secs(seconds));
                 self.persistent_state.timer_state = Some(TimerDuration::CustomSeconds(seconds));
                 self.update_config();
-                self.set_stay_awake(true);
+                return self.toggle_caffeine(true);
             }
             Message::CustomDuration => {
                 self.secondary_window = Some(SecondaryWindow::CustomDuration {
@@ -214,7 +230,7 @@ impl cosmic::Application for Window {
                     self.secondary_window = None;
                     self.persistent_state.timer_state = Some(TimerDuration::CustomSeconds(seconds));
                     self.update_config();
-                    self.set_stay_awake(true);
+                    return self.toggle_caffeine(true);
                 }
             }
             Message::RememberStateToggle(chain, remember_state) => {
@@ -341,9 +357,7 @@ impl cosmic::Application for Window {
     }
 
     fn on_app_exit(&mut self) -> Option<Message> {
-        if let Err(e) = self.caffeine.cleanup() {
-            tracing::error!("Failed to exit gracefully: {e:?}");
-        }
+        self.caffeine.take_cookie();
         None
     }
 }
@@ -355,30 +369,27 @@ impl Window {
         }
     }
 
-    fn set_stay_awake(&mut self, is_stay_awake: bool) {
+    fn toggle_caffeine(&mut self, enable: bool) -> app::Task<Message> {
         tracing::info!(
             "{} stay awake",
-            if is_stay_awake {
-                "Enabling"
-            } else {
-                "Disabling"
-            }
+            if enable { "Enabling" } else { "Disabling" }
         );
-        let changed = self.caffeine.is_caffeinated() != is_stay_awake;
-        match if is_stay_awake {
-            self.caffeine
-                .caffeinate()
-                .and_then(|_| Ok(chain::Toggler::on(STAY_AWAKE_CONTROLS.clone(), 1.)))
+        if enable {
+            self.caffeine.clear_cookie();
+            Task::perform(caffeine::inhibit(), Message::DbusInhibitResult)
+                .map(cosmic::action::app)
         } else {
             self.timer.cancel();
             self.timer_string = None;
-            self.caffeine
-                .decaffeinate()
-                .and_then(|_| Ok(chain::Toggler::off(STAY_AWAKE_CONTROLS.clone(), 1.)))
-        } {
-            Ok(chain) if changed => self.timeline.set_chain(chain).start(),
-            Err(e) => tracing::error!("Failed to stay awake: {e:?}"),
-            _ => {}
+            if let Some(cookie) = self.caffeine.take_cookie() {
+                Task::perform(
+                    caffeine::uninhibit(cookie),
+                    |_| Message::DbusUninhibitResult,
+                )
+                .map(cosmic::action::app)
+            } else {
+                Task::none()
+            }
         }
     }
 }


### PR DESCRIPTION
## Description

Clicking the applet icon in the panel to enable/disable caffeine causes the applet to crash/disappear.

## Root Cause

Two issues:

### 1. Blocking D-Bus calls on the main thread
`caffeine.rs` used `zbus::blocking::Connection` which blocks the main iced/tokio event loop when calling `org.freedesktop.ScreenSaver`. This blocks Wayland event processing, causing the compositor to disconnect the applet.

**Fix:** Replaced blocking zbus with async zbus. The `toggle_caffeine()` method now returns an async `Task::perform()` that runs the D-Bus call on the tokio runtime without blocking the UI thread.

### 2. Multiple `.expect()` / `.unwrap()` calls with `panic = "abort"`
`Cargo.toml` has `panic = "abort"` in the release profile, meaning any panic immediately kills the process. The code had several places that could panic:
- `confy::store().expect()` on config save
- `confy::load().expect()` on config load
- `main_window_id().unwrap()` in popup creation
- `parse().expect()` in custom duration input
- `load_fallback_language().expect()` in localization

**Fix:** Replaced all `.expect()` and `.unwrap()` with graceful error handling (`unwrap_or_default`, `if let Some`, `unwrap_or`, error logging).

## Changes
- `caffeine.rs`: async zbus API, simplified Caffeine struct
- `window.rs`: async toggle via `Task::perform`, new message variants, graceful error handling
- `Cargo.toml`: removed `blocking-api` zbus feature
- `localize.rs`: removed `.expect()` on language loading